### PR TITLE
Changed scope for field template override

### DIFF
--- a/Resources/config/ez_field_templates.yml
+++ b/Resources/config/ez_field_templates.yml
@@ -1,4 +1,4 @@
 system:
-    global:
+    default:
         field_templates:
             - {template: NovaeZSEOBundle:fields:novaseometas.html.twig, priority: 0}


### PR DESCRIPTION
Definition for field template had scope of "global", which caused problems when having custom field templates overrides defined, as the definition from this bundle had precedence. Also, if set to global, it is not possible to override novaseometas_field block. 

This PR sets the scope to "default" which fixes the issue.