### PR TITLE
SELECT query malformed

### DIFF
--- a/Core/MetaNameSchema.php
+++ b/Core/MetaNameSchema.php
@@ -48,6 +48,13 @@ class MetaNameSchema extends NameSchemaService
     protected $imageVariationService;
 
     /**
+     * Meta content data max length
+     *
+     * @var int
+     */
+    protected $fieldContentMaxLength = 255;
+
+    /**
      * Set prioritized languages
      *
      * @param array $languages
@@ -88,6 +95,12 @@ class MetaNameSchema extends NameSchemaService
      */
     public function resolveMeta( Meta $meta, Content $content, ContentType $contentType = null )
     {
+
+        $this->settings = array(
+            'limit' => $this->fieldContentMaxLength,
+            'sequence' => '...',
+        );
+
         if ( $contentType === null )
         {
             $contentType = $this->repository->getContentTypeService()->loadContentType(

--- a/ezpublish_legacy/novaseo/datatypes/novaseometas/novaseometastype.php
+++ b/ezpublish_legacy/novaseo/datatypes/novaseometas/novaseometastype.php
@@ -207,7 +207,7 @@ class NovaSeoMetasType extends eZDataType
         $db         = eZDB::instance();
         $metasArray = $db->arrayQuery(
             "SELECT * FROM " .  $db->escapeString( self::TABLE ) . " WHERE
-                    objectattribute_id = {$contentObjectAttribute->attribute( 'id' )},
+                    objectattribute_id = {$contentObjectAttribute->attribute( 'id' )} AND 
                     objectattribute_version= {$contentObjectAttribute->attribute( 'version' )}
                     "
         );


### PR DESCRIPTION
Generated SQL:
    ...WHERE foo=bar, bar=foo...

Should be :
    ...WHERE foo=bar AND bar=foo...

This manifests at least upon moving content with meta data.