### PR TITLE
Specify language(s) when loading content for performance reasons.

### DIFF
--- a/Twig/NovaeZSEOExtension.php
+++ b/Twig/NovaeZSEOExtension.php
@@ -109,17 +109,18 @@ class NovaeZSEOExtension extends \Twig_Extension
     public function computeMetas( Field $field, ContentInfo $contentInfo )
     {
         $fallback = false;
+        $languages = $this->configResolver->getParameter( 'languages' );
         $contentType = $this->eZRepository->getContentTypeService()->loadContentType(
             $contentInfo->contentTypeId
         );
-        $content = $this->eZRepository->getContentService()->loadContentByContentInfo( $contentInfo );
+        $content = $this->eZRepository->getContentService()->loadContentByContentInfo( $contentInfo, $languages );
         $contentMetas = $this->innerComputeMetas( $content, $field, $contentType, $fallback );
         if ( $fallback )
         {
             $rootNode = $this->eZRepository->getLocationService()->loadLocation(
                 $this->configResolver->getParameter( "content.tree_root.location_id" )
             );
-            $rootContent = $this->eZRepository->getContentService()->loadContentByContentInfo( $rootNode->contentInfo );
+            $rootContent = $this->eZRepository->getContentService()->loadContentByContentInfo( $rootNode->contentInfo, $languages );
             $rootContentType = $this->eZRepository->getContentTypeService()->loadContentType(
                 $rootContent->contentInfo->contentTypeId
             );


### PR DESCRIPTION
After discussing cache size issues (we have a site with 40+ languages / sites) with @andrerom he pointed out:

 > So @rihards, you can check and see if you can be able to specify languages on all ContentService->loadContent* calls ​_(loadContentInfo calls not affected as they don’t load fields data), this will at least make sure the files don’t get to big.

I found that the language isn't specified in these two calls in the bundle. It's a small fix, but can be quite important to huge sites. Otherwise you end up with object cache files that are 1mb+ in size. And those are quite intensive to decode and serialise.