### PR TITLE
Fieldtype not registered when running indexation using ez-platform-solr-search-engine

### DIFF
--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -11,6 +11,12 @@ services:
         tags:
             - {name: ezpublish.fieldType, alias: novaseometas}
 
+    # Marking fieldtype as unindexable for ez platform solr bundle to stop errors
+    novactive.fieldType.novaseometas.indexable.unindexed:
+        class: %ezpublish.fieldType.indexable.unindexed.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: novaseometas}
+
     novactive.novaseobundle.fieldType.novaseometas.externalStorage:
         class: %novactive.novaseobundle.fieldType.novaseometas.externalStorage.class%
         tags:


### PR DESCRIPTION
When using the ez-platform-solr-search-engine bundle the indexation process fails with and error noting that the novaseometas field type is not registered.

I have updated the fieldtypes.yml file to include the registration for the field type using the default unindexed class. Thus allowing indexation of content to complete as expected.