### PR TITLE
Fixed issue with missing second parameter for NameSchemaService

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -19,9 +19,11 @@ services:
 
     novactive.novaseobundle.meta_name_schema:
         class: %novactive.novaseobundle.meta_name_schema.class%
-        arguments: [@ezpublish.api.repository]
+        arguments: [@ezpublish.api.repository, @ezpublish.repository.helper.nameable_field_type_registry]
         calls:
             - [setLanguages, ["$languages$"]]
             - [setHtml5Converter, ["@ezpublish.fieldtype.ezxmltext.converter.html5"]]
             - [setImageVariationService, ["@ezpublish.fieldtype.ezimage.variation_service", @ezpublish.fieldtype.ezimage]]
 
+    ezpublish.repository.helper.nameable_field_type_registry:
+        class: eZ\Publish\Core\Repository\Helper\NameableFieldTypeRegistry


### PR DESCRIPTION
After upgrading to the latest version of eZ Publish 5.4.x we had an exception:

Catchable Fatal Error: Argument 2 passed to eZ\Publish\Core\Repository\NameSchemaService::__construct() must be an instance of eZ\Publish\Core\Repository\Helper\NameableFieldTypeRegistry, none given

This PR solves the issue by adding missing `NameableFieldTypeRegistry` dependency for the `NameSchemaService` constructor.
