### PR TITLE
Prevent showing exception if one of the metas field not exists

### DIFF
--- a/Twig/NovaeZSEOExtension.php
+++ b/Twig/NovaeZSEOExtension.php
@@ -183,7 +183,7 @@ class NovaeZSEOExtension extends \Twig_Extension
                     $fieldDefinition = $contentType->getFieldDefinition( $fieldDefIdentifier );
                     $configuration   = $fieldDefinition->getFieldSettings()['configuration'];
                     // but if we need something is the configuration we take it
-                    if ( $configuration[$meta->getName()] )
+                    if ( isset($configuration[$meta->getName()]) )
                     {
                         $meta->setContent( $configuration[$meta->getName()] );
                     }


### PR DESCRIPTION
We have a situation when we've added a new property (`canonical`) to the list of existing fields defined in config.yml configuration (`novae_zseo:fieldtype_metas`).

Now, if we want to view content with added `metas` field we have an exception:

`An exception has been thrown during the rendering of a template ("Notice: Undefined index: canonical") in NovaeZSEOBundle:fields:novaseometas.html.twig at line 4.`

This PR solves the issue without need of editing required content.