### PR TITLE
Fix issue that break fallback to yml configuration

### DIFF
--- a/Twig/NovaeZSEOExtension.php
+++ b/Twig/NovaeZSEOExtension.php
@@ -183,7 +183,7 @@ class NovaeZSEOExtension extends \Twig_Extension
                     $fieldDefinition = $contentType->getFieldDefinition( $fieldDefIdentifier );
                     $configuration   = $fieldDefinition->getFieldSettings()['configuration'];
                     // but if we need something is the configuration we take it
-                    if ( isset($configuration[$meta->getName()]) )
+                    if ( isset($configuration[$meta->getName()]) && !empty($configuration[$meta->getName()])  )
                     {
                         $meta->setContent( $configuration[$meta->getName()] );
                     }


### PR DESCRIPTION
A simple check if $configuration[$meta->getName()] for the field is not empty before overriding configuration pattern.
Otherwise the configuration set from yml file is overriden with empty data.