### PR TITLE
Fix issue where hreflang meta is generated for every available langua…

### DIFF
--- a/Resources/views/seometas_metaslinks.html.twig
+++ b/Resources/views/seometas_metaslinks.html.twig
@@ -25,7 +25,9 @@
 {% if  ezpublish.availableLanguages|length > 1 %}
     {% for lang in ezpublish.availableLanguages %}
         {% if location is defined %}
-            <link rel="alternate" data-sa="{{ ezpublish.translationSiteAccess( lang ) }}" hreflang="{{ lang|getposixlocale_novaseometas }}" href="{{ url( location, {"siteaccess": ezpublish.translationSiteAccess( lang ) } ) }}" />
+            {% if lang in content.versionInfo.languageCodes %}
+                <link rel="alternate" data-sa="{{ ezpublish.translationSiteAccess( lang ) }}" hreflang="{{ lang|getposixlocale_novaseometas }}" href="{{ url( location, {"siteaccess": ezpublish.translationSiteAccess( lang ) } ) }}" />
+            {% endif %}
         {% else %}
             {% set route = ez_route( params={"language": lang} ) %}
             {# we can't do the diff with 404 #}


### PR DESCRIPTION
Currently, if a content is not translated in every available language, missing ones will generate hreflang metas with "/view/content" URLs, which can be problematic if those end up on a 404 or even 500 in some cases.

I added a test to avoid that case by checking in the current version of the content contains that specific language, in which case we do not add an hreflang for it.