### PR TITLE
fix keywords typo in USAGE.md

### DIFF
--- a/Resources/doc/USAGE.md
+++ b/Resources/doc/USAGE.md
@@ -94,13 +94,13 @@ nova_ezseo:
                 description:
                     label: 'Description'
                     default_pattern: "<description|short_description|title|name>"
-                keyword:
+                keywords:
                     label: 'Keywords'
                     default_pattern: ~
 
 ```
 
-This configuration defines 3 metas, _title_, _description_ and _keyword_
+This configuration defines 3 metas, _title_, _description_ and _keywords_
 
 > You can add what you want to here.
 


### PR DESCRIPTION
Variable name `keyword` should be changed to `keywords`, as in [default_settings.yml#L42](https://github.com/Novactive/NovaeZSEOBundle/blob/develop-ezplatform/Resources/config/default_settings.yml#L42)