### PR TITLE
fix for twig2

### DIFF
--- a/Twig/NovaeZSEOExtension.php
+++ b/Twig/NovaeZSEOExtension.php
@@ -24,7 +24,7 @@ use Novactive\Bundle\eZSEOBundle\Core\CustomFallbackInterface;
 /**
  * Class NovaeZSEOExtension
  */
-class NovaeZSEOExtension extends \Twig_Extension
+class NovaeZSEOExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * The eZ Publish object name pattern service (extended)


### PR DESCRIPTION
For php:7.1 (php>=7.0) twig will be installed in version >=2.0, where `Twig_Extension_GlobalsInterface` should be implemented to use `Twig_Extension:getGlobals()`.
[ezpublish-kernel example](https://github.com/ezsystems/ezpublish-kernel/blob/7.0/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/CoreExtension.php#L15) 

