### PR TITLE
Image and url white space encoded

### DIFF
--- a/Resources/views/fields/novaseometas.html.twig
+++ b/Resources/views/fields/novaseometas.html.twig
@@ -12,6 +12,8 @@
             {% elseif meta.name == "canonical" %}
                 <link rel="canonical" href="{{ meta.content }}" />
                 {% set isCanonicalFind = true %}
+            {% elseif 'image' in meta.name|trim or 'url' in meta.name|trim %}
+                <meta property="{{ meta.name }}" content="{{ meta.content | replace({' ': '%20'})  }}"/>
             {% elseif meta.name|trim starts with "og" %}
                 <meta property="{{ meta.name }}" content="{{ meta.content }}"/>
             {% else %}


### PR DESCRIPTION
There are times when users have images with white space in the file name. 
When uploaded trough eZ admin it will render and show properly on page.
However image urls with white space in it wont be seen by facebook and twitter when you share the link of the article that has such image set as image meta tag.