### PR TITLE
Delete field data in case there is some before storing

### DIFF
--- a/Core/FieldType/Metas/MetasStorage.php
+++ b/Core/FieldType/Metas/MetasStorage.php
@@ -31,8 +31,6 @@ class MetasStorage extends GatewayBasedStorage
      */
     public function storeFieldData( VersionInfo $versionInfo, Field $field, array $context )
     {
-        $this->getGateway( $context )->deleteFieldData($versionInfo, array($field->id));
-
         if ( empty( $field->value->externalData ) )
         {
             return;
@@ -40,6 +38,12 @@ class MetasStorage extends GatewayBasedStorage
 
         /** @var LegacyStorage $gateway */
         $gateway = $this->getGateway( $context );
+
+        $metas = $gateway->getFieldData( $versionInfo, $field );
+        if ($metas) {
+            $gateway->deleteFieldData( $versionInfo, array($field->id) );
+        }
+
         $gateway->storeFieldData( $versionInfo, $field );
     }
 

--- a/Core/FieldType/Metas/MetasStorage.php
+++ b/Core/FieldType/Metas/MetasStorage.php
@@ -31,6 +31,8 @@ class MetasStorage extends GatewayBasedStorage
      */
     public function storeFieldData( VersionInfo $versionInfo, Field $field, array $context )
     {
+        $this->getGateway( $context )->deleteFieldData($versionInfo, array($field->id));
+
         if ( empty( $field->value->externalData ) )
         {
             return;


### PR DESCRIPTION
In some instances where you update a content throught the eZPublish API, a database exception was thrown because these data were already set when creating the contentUpdateDraft.

To prevent that, a call to deleteFieldData was added before storing any new data.