### PR TITLE
Use url function to enforce absolute urls

### DIFF
--- a/Resources/views/fields/novaseometas.html.twig
+++ b/Resources/views/fields/novaseometas.html.twig
@@ -32,7 +32,7 @@
         {% endif %}
     {% endfor %}
     {% if contentInfo.mainLocationId is defined and isCanonicalFind == false %}
-        <link rel="canonical" href="{{ path( 'ez_urlalias', {'locationId': contentInfo.mainLocationId} ) }}" />
+        <link rel="canonical" href="{{ url( 'ez_urlalias', {'locationId': contentInfo.mainLocationId} ) }}" />
     {% endif %}
     {% if isTtitleFind == false %}
         <title>{{ ez_content_name( contentInfo ) }}</title>

--- a/Resources/views/seometas_metaslinks.html.twig
+++ b/Resources/views/seometas_metaslinks.html.twig
@@ -11,7 +11,7 @@
 
 {% if content is defined and content.fields[novae_zseo.fieldtype_metas_identifier] is not defined %}
     {% if content.contentInfo.mainLocationId is defined %}
-        <link rel="canonical" href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}" />
+        <link rel="canonical" href="{{ url( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}" />
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
General consensus seems to be that canonical links should be absolute: https://stackoverflow.com/questions/8467938/do-canonical-links-require-a-full-domain

Suggest using the url function here to enforce that by default.