### PR TITLE
Injected lower layer Variation Handler into MetaNameSchema

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -35,7 +35,8 @@ services:
         calls:
             - [setLanguages, ["$languages$"]]
             - [setRichTextConverter, ["@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"]]
-            - [setImageVariationService, ["@ezpublish.fieldType.ezimage.variation_service", "@ezpublish.fieldType.ezimage"]]
+            # Note: injecting lower layer Variation Handler (AliasGenerator) as a workaround for missing Public API objects context
+            - [setImageVariationService, ["@ezpublish.image_alias.imagine.variation.imagine_alias_generator", "@ezpublish.fieldType.ezimage"]]
 
     novactive.novaseobundle.installer.field:
         class: "%novactive.novaseobundle.installer.field.class%"


### PR DESCRIPTION
This PR is a workaround for obtaining Image Variation for objects not fetched from eZ Platform Repository.

Background: due to performance issues when trying to solve missing with and height of image Variations, additional Image Variation Cache layer has been introduced via ezsystems/ezpublish-kernel#2325, which requires using [here](https://github.com/Novactive/NovaeZSEOBundle/blob/3.0.0-rc1/Core/MetaNameSchema.php#L288-L295) fully qualified Public API objects obtained from Repository when calling `getVariation`.

This workaround bypasses that new layer until we figure out cleaner solution.

Steps to reproduce the issue we have now: 
1. Install `dev-master` version of [ezsystems/ezplatform-demo](https://github.com/ezsystems/ezplatform-demo) 
2. Go to home page in a web browser to see the exception.

cc @Plopix @damianz5 @SylvainGuittard