### PR TITLE
Inject proper VariationHandler to allow usage of PlaceholderAliasGenerator

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -36,7 +36,7 @@ services:
             - [setLanguages, ["$languages$"]]
             - [setRichTextConverter, ["@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"]]
             # Note: injecting lower layer Variation Handler (AliasGenerator) as a workaround for missing Public API objects context
-            - [setImageVariationService, ["@ezpublish.image_alias.imagine.variation.imagine_alias_generator", "@ezpublish.fieldType.ezimage"]]
+            - [setImageVariationService, ["@ezpublish.image_alias.imagine.alias_generator", "@ezpublish.fieldType.ezimage"]]
 
     novactive.novaseobundle.installer.field:
         class: "%novactive.novaseobundle.installer.field.class%"


### PR DESCRIPTION
Unfortunately, as for now, `PlaceholderAliasGenerator` (introduced in: https://github.com/ezsystems/ezpublish-kernel/pull/2311) is not working. Therefore, it's a little inconvenient to work with the project which uses `NovaeZSEOBundle` without having a full images library locally. 

This PR changes injected service to the abstract one, which is decorated if PlaceholderAliasGenerator is configured. It's sort of improvement for what has been done in: https://github.com/Novactive/NovaeZSEOBundle/pull/80.


@Plopix / @alongosz / @damianz5 / @SylvainGuittard could you take a look, please?