### PR TITLE
Fix for naming strategy and getLogsHistory

### DIFF
--- a/bundle/Controller/Admin/RedirectController.php
+++ b/bundle/Controller/Admin/RedirectController.php
@@ -259,7 +259,7 @@ class RedirectController extends Controller
         if (!$permissionResolver->hasAccess('novaseobundle.redirects', 'import')) {
             throw new AccessDeniedException('Limited access !!!');
         }
-        $log = $entityManager->getRepository('NovaeZSEOBundle:RedirectImportHistory')->find($id);
+        $log = $entityManager->getRepository('Novactive\Bundle\eZSEOBundle\Entity\RedirectImportHistory')->find($id);
         if ($log instanceof RedirectImportHistory) {
             $fileContent = $importUrlsHelper->downloadFile($log);
             if ($fileContent) {

--- a/bundle/Core/Helper/ImportUrlsHelper.php
+++ b/bundle/Core/Helper/ImportUrlsHelper.php
@@ -237,6 +237,6 @@ class ImportUrlsHelper
 
     public function getLogsHistory(): array
     {
-        return $this->entityManager->getRepository('NovaeZSEOBundle:RedirectImportHistory')->findAll();
+        return $this->entityManager->getRepository('Novactive\Bundle\eZSEOBundle\Entity\RedirectImportHistory')->findAll();
     }
 }

--- a/bundle/Core/SiteAccessAwareEntityManagerFactory.php
+++ b/bundle/Core/SiteAccessAwareEntityManagerFactory.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 
 class SiteAccessAwareEntityManagerFactory
 {
@@ -82,6 +83,7 @@ class SiteAccessAwareEntityManagerFactory
         $config->setProxyNamespace('eZSEOBundle\Proxies');
         $config->setAutoGenerateProxyClasses($this->settings['debug']);
         $config->setEntityListenerResolver($this->resolver);
+        $config->setNamingStrategy(new UnderscoreNamingStrategy());
 
         return EntityManager::create($connection, $config);
     }


### PR DESCRIPTION
To avoid error like "Unknown Entity namespace alias 'NovaeZSEOBundle'." notation of class name parameter of getRepository method  in ImportUrlsHelper class (getLogsHistory function) should be changed.

As the given db schema prescribes column naming with underscore the ORM naming strategy should be set when creating EntityManager in SiteAccessAwareManagerFactory.