### PR TITLE
Fixes :

### DIFF
--- a/bundle/Resources/views/fields/novaseometas_admin.html.twig
+++ b/bundle/Resources/views/fields/novaseometas_admin.html.twig
@@ -3,13 +3,13 @@
 {% block novaseometas_field %}
     <ul class="novaseobundle-preview-field">
     {% for meta in field.value.metas %}
-        <li class="ez-field meta-value">
-            {% if nova_ezseo.fieldtype_metas[meta.name] is defined %}
+        {% if nova_ezseo.fieldtype_metas[meta.name] is defined %}
+            <li class="ez-field meta-value">
                 {% set default_value = nova_ezseo.fieldtype_metas[meta.name] %}
                 <b>{{ default_value.label }}:</b>
-                {{ meta.isEmpty() ? default_value.default_pattern|raw : meta.content }}
-            {% endif %}
-        </li>
+                {{ meta.isEmpty() ? default_value.default_pattern|raw|escape : meta.content }}
+            </li>
+        {% endif %}
     {% endfor %}
     </ul>
     <div class="nova-signature">


### PR DESCRIPTION
- escape default_pattern (if we set for example <title>, the tag is interpreted by html and break the page)
- check if fieldtype_metas[meta.name] is still defined in config. Bug crashs on dev mode