### PR TITLE
Made SEO and Sitemap controllers compatible with eZ Platform 3.0

### DIFF
--- a/bundle/Controller/SitemapController.php
+++ b/bundle/Controller/SitemapController.php
@@ -22,7 +22,9 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -34,6 +36,18 @@ class SitemapController extends Controller
      * @var int
      */
     const PACKET_MAX = 1000;
+
+    private $kernel;
+    private $configResolver;
+
+    public function __construct (
+        KernelInterface $kernel,
+        ConfigResolverInterface $configResolver
+    )
+    {
+        $this->kernel = $kernel;
+        $this->configResolver = $configResolver;
+    }
 
     /**
      * Get the common Query.
@@ -151,7 +165,7 @@ class SitemapController extends Controller
              */
             $location = $searchHit->valueObject;
             try {
-                $url = $this->generateUrl($location, [], UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = $this->generateUrl('ez_urlalias', ['locationId' => $location->id], UrlGeneratorInterface::ABSOLUTE_URL);
             } catch (\Exception $exception) {
                 if ($this->has('logger')) {
                     $this->get('logger')->error('NovaeZSEO: '.$exception->getMessage());

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -45,6 +45,12 @@ services:
     Novactive\Bundle\eZSEOBundle\Controller\Admin\RedirectController:
         tags: ['controller.service_arguments']
 
+    Novactive\Bundle\eZSEOBundle\Controller\SEOController:
+        tags: ['controller.service_arguments']
+
+    Novactive\Bundle\eZSEOBundle\Controller\SitemapController:
+        tags: ['controller.service_arguments']
+
     Novactive\Bundle\eZSEOBundle\Twig\NovaeZSEOExtension: ~
     Novactive\Bundle\eZSEOBundle\Core\DummyCustomFallback: ~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Version 5.0.0 is mostly compatible with eZ Platform 3.0, but it seems Public controllers (SEOController and SitemapController) were not. This PR includes fixes to make them work.