### PR TITLE
fix controller has no container set error

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -42,6 +42,10 @@ services:
             - { name: ez.fieldFormMapper.value, fieldType: novaseometas }
 
     # OTHER SERVICES
+    Novactive\Bundle\eZSEOBundle\Controller\SitemapController:
+        tags: ['controller.service_arguments']
+    Novactive\Bundle\eZSEOBundle\Controller\SEOController:
+        tags: ['controller.service_arguments']
     Novactive\Bundle\eZSEOBundle\Controller\Admin\RedirectController:
         tags: ['controller.service_arguments']
 


### PR DESCRIPTION
Fix `"Novactive\Bundle\eZSEOBundle\Controller\SitemapController" has no container set, did you forget to define it as a service subscriber?`

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
