### PR TITLE
fix controller has no container set error, fix generate route

### DIFF
--- a/bundle/Controller/SEOController.php
+++ b/bundle/Controller/SEOController.php
@@ -50,7 +50,7 @@ class SEOController extends Controller
                 $robots[] = "Allow: {$rule}";
             }
         }
-        if ('prod' !== $this->get('kernel')->getEnvironment()) {
+        if ('prod' !== $this->getParameter('kernel.environment')) {
             $robots[] = 'Disallow: /';
         }
 

--- a/bundle/Controller/SitemapController.php
+++ b/bundle/Controller/SitemapController.php
@@ -151,7 +151,11 @@ class SitemapController extends Controller
              */
             $location = $searchHit->valueObject;
             try {
-                $url = $this->generateUrl($location, [], UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = $this->generateUrl(
+                    'ez_urlalias',
+                    ['locationId' => $location->id],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
             } catch (\Exception $exception) {
                 if ($this->has('logger')) {
                     $this->get('logger')->error('NovaeZSEO: '.$exception->getMessage());

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -42,6 +42,10 @@ services:
             - { name: ez.fieldFormMapper.value, fieldType: novaseometas }
 
     # OTHER SERVICES
+    Novactive\Bundle\eZSEOBundle\Controller\SitemapController:
+        tags: ['controller.service_arguments']
+    Novactive\Bundle\eZSEOBundle\Controller\SEOController:
+        tags: ['controller.service_arguments']
     Novactive\Bundle\eZSEOBundle\Controller\Admin\RedirectController:
         tags: ['controller.service_arguments']
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Fixed `"Novactive\Bundle\eZSEOBundle\Controller\SitemapController" has no container set, did you forget to define it as a service subscriber?`
Fixed `generateUrl` compatibility with eZ v3