### PR TITLE
Add possibility to manage nb result per page (packet_max) by env variable

### DIFF
--- a/bundle/Controller/SitemapController.php
+++ b/bundle/Controller/SitemapController.php
@@ -90,7 +90,7 @@ class SitemapController extends Controller
         $sitemap->formatOutput = true;
 
         // create an index if we are greater than th PACKET_MAX
-        if ($resultCount > static::PACKET_MAX) {
+        if ($resultCount > $this->getPacketMax()) {
             $root = $sitemap->createElement('sitemapindex');
             $root->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
             $sitemap->appendChild($root);
@@ -125,8 +125,8 @@ class SitemapController extends Controller
         $root->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $sitemap->appendChild($root);
         $query         = $this->getQuery();
-        $query->limit  = static::PACKET_MAX;
-        $query->offset = static::PACKET_MAX * ($page - 1);
+        $query->limit  = $this->getPacketMax();
+        $query->offset = $this->getPacketMax() * ($page - 1);
 
         $searchService = $this->getRepository()->getSearchService();
 
@@ -174,7 +174,7 @@ class SitemapController extends Controller
      */
     protected function fillSitemapIndex(DOMDocument $sitemap, int $numberOfResults, DOMElement $root): void
     {
-        $numberOfPage = (int) ceil($numberOfResults / static::PACKET_MAX);
+        $numberOfPage = (int) ceil($numberOfResults / $this->getPacketMax());
         for ($sitemapNumber = 1; $sitemapNumber <= $numberOfPage; ++$sitemapNumber) {
             $sitemapElt = $sitemap->createElement('sitemap');
 
@@ -200,4 +200,14 @@ class SitemapController extends Controller
             $root->appendChild($sitemapElt);
         }
     }
+
+    /**
+     * @return int
+     */
+    public function getPacketMax()
+    {
+        return $this->getConfigResolver()->getParameter('packet_max', 'nova_ezseo');
+    }
+
+
 }

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -80,3 +80,4 @@ parameters:
             label: 'Twitter - Image'
             default_pattern: "<image|picture>"
             icon: 'twitter-square'
+    nova_ezseo.default.packet_max: 1000


### PR DESCRIPTION


Thanks for your pull request! We love contributions.

However, this repository is what we call a "subtree split": a read-only copy of one directory of the main repository. It is used by Composer to allow developers to depend on specific bundles.

If you want to contribute, you should instead open a pull request on the main repository:

https://github.com/Novactive/Nova-eZPlatform-Bundles

Thank you for your contribution!

PS: if you haven't already, please add tests.
