### PR TITLE
Fix return method type

### DIFF
--- a/bundle/Core/Helper/ImportUrlsHelper.php
+++ b/bundle/Core/Helper/ImportUrlsHelper.php
@@ -161,15 +161,16 @@ class ImportUrlsHelper
 
     public function checkUrlDestinationExist(string $destination): bool
     {
-        $urlExists = false;
-
         try {
-            $urlExists = $this->urlWildCardService->translate($destination);
+            if($$this->urlWildCardService->translate($destination) instanceof URLWildcardTranslationResult) {
+                return true;
+            }
+
         } catch (\Exception $e) {
             $this->logger->log(LogLevel::ERROR, $e->getMessage());
         }
 
-        return $urlExists;
+        return false;
     }
 
     public function saveUrls(string $filePath, string $source, string $destination): array


### PR DESCRIPTION
The Method ImportUrlsHelper::checkUrlDestinationExist() has to return a bool, if the return type is instanceof URLWildcardTranslationResult class then it fails 
