### PR TITLE
Enable SiteAware config matching for missing fields

### DIFF
--- a/bundle/DependencyInjection/NovaeZSEOExtension.php
+++ b/bundle/DependencyInjection/NovaeZSEOExtension.php
@@ -70,6 +70,13 @@ class NovaeZSEOExtension extends Extension implements PrependExtensionInterface
         $processor->mapSetting('limit_to_rootlocation', $config);
         $processor->mapSetting('display_images_in_sitemap', $config);
         $processor->mapSetting('robots', $config);
+        $processor->mapSetting('robots_disallow', $config);
+        $processor->mapSetting('custom_fallback_service', $config);
+        $processor->mapSetting('sitemap_excludes', $config);
+        $processor->mapSetting('sitemap_includes', $config);
+        $processor->mapSetting('default_metas', $config);
+        $processor->mapSetting('default_links', $config);
+
         $processor->mapConfigArray('fieldtype_metas', $config, ContextualizerInterface::MERGE_FROM_SECOND_LEVEL);
         $processor->mapConfigArray('default_metas', $config);
         $processor->mapConfigArray('default_links', $config);


### PR DESCRIPTION
Thanks for your pull request! We love contributions.

However, this repository is what we call a "subtree split": a read-only copy of one directory of the main repository. It is used by Composer to allow developers to depend on specific bundles.

If you want to contribute, you should instead open a pull request on the main repository:

https://github.com/Novactive/Nova-eZPlatform-Bundles

Thank you for your contribution!

PS: if you haven't already, please add tests.
